### PR TITLE
ADCM-1549 any_errors_fatalpriority over max_fail_percentage

### DIFF
--- a/changelogs/fragments/ignore_max_fail_percentage.yml
+++ b/changelogs/fragments/ignore_max_fail_percentage.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - resolve any_errors_fatal and max_fail_percentage conflicting behavior in favor of former

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -419,8 +419,13 @@ class StrategyModule(StrategyBase):
                 display.debug("done checking for any_errors_fatal")
 
                 display.debug("checking for max_fail_percentage")
-                if iterator._play.max_fail_percentage is not None and len(results) > 0:
-                    percentage = iterator._play.max_fail_percentage / 100.0
+                # any_errors_fatal and max_fail_percentage have conflicting behavior
+                # any_errors_fatal is decided to have priority and max_fail_percentage is (re)setted to 0
+                max_fail_percentage = iterator._play.max_fail_percentage
+                if any_errors_fatal:
+                    max_fail_percentage = 0
+                if max_fail_percentage is not None and len(results) > 0:
+                    percentage = max_fail_percentage / 100.0
 
                     if (len(self._tqm._failed_hosts) / iterator.batch_size) > percentage:
                         for host in hosts_left:


### PR DESCRIPTION
##### SUMMARY
Params `any_errors_fata`l and `max_fail_percentage` have conflicting behavior;
`any_errors_fatal` is decided to have priority and `max_fail_percentage` is (re)setted to 0

Fixes ADCM-1549
Fixes #46447


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
plugin `strategy 'linear'`

